### PR TITLE
CURE: Presenter structure updates

### DIFF
--- a/Migrations/20250630011845_UpdatePresenterStructure.Designer.cs
+++ b/Migrations/20250630011845_UpdatePresenterStructure.Designer.cs
@@ -4,6 +4,7 @@ using KiCData.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace KiCData.Migrations
 {
     [DbContext(typeof(KiCdbContext))]
-    partial class KiCdbContextModelSnapshot : ModelSnapshot
+    [Migration("20250630011845_UpdatePresenterStructure")]
+    partial class UpdatePresenterStructure
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250630011845_UpdatePresenterStructure.cs
+++ b/Migrations/20250630011845_UpdatePresenterStructure.cs
@@ -1,0 +1,176 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KiCData.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdatePresenterStructure : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Member_Presenter_PresenterId",
+                table: "Member");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Presentation_Presenter_PresenterId",
+                table: "Presentation");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Presentation_PresenterId",
+                table: "Presentation");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Member_PresenterId",
+                table: "Member");
+
+            migrationBuilder.DropColumn(
+                name: "PresenterId",
+                table: "Presentation");
+
+            migrationBuilder.DropColumn(
+                name: "PresenterId",
+                table: "Member");
+
+            migrationBuilder.AddColumn<int>(
+                name: "MemberId",
+                table: "Presenter",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "PresentationPresenter",
+                columns: table => new
+                {
+                    PresentationsId = table.Column<int>(type: "int", nullable: false),
+                    PresentersId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PresentationPresenter", x => new { x.PresentationsId, x.PresentersId });
+                    table.ForeignKey(
+                        name: "FK_PresentationPresenter_Presentation_PresentationsId",
+                        column: x => x.PresentationsId,
+                        principalTable: "Presentation",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PresentationPresenter_Presenter_PresentersId",
+                        column: x => x.PresentersId,
+                        principalTable: "Presenter",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "PresenterSocial",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Platform = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Handle = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    PresenterId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PresenterSocial", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PresenterSocial_Presenter_PresenterId",
+                        column: x => x.PresenterId,
+                        principalTable: "Presenter",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Presenter_MemberId",
+                table: "Presenter",
+                column: "MemberId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PresentationPresenter_PresentersId",
+                table: "PresentationPresenter",
+                column: "PresentersId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PresenterSocial_PresenterId",
+                table: "PresenterSocial",
+                column: "PresenterId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Presenter_Member_MemberId",
+                table: "Presenter",
+                column: "MemberId",
+                principalTable: "Member",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Presenter_Member_MemberId",
+                table: "Presenter");
+
+            migrationBuilder.DropTable(
+                name: "PresentationPresenter");
+
+            migrationBuilder.DropTable(
+                name: "PresenterSocial");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Presenter_MemberId",
+                table: "Presenter");
+
+            migrationBuilder.DropColumn(
+                name: "MemberId",
+                table: "Presenter");
+
+            migrationBuilder.AddColumn<int>(
+                name: "PresenterId",
+                table: "Presentation",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PresenterId",
+                table: "Member",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Presentation_PresenterId",
+                table: "Presentation",
+                column: "PresenterId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Member_PresenterId",
+                table: "Member",
+                column: "PresenterId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Member_Presenter_PresenterId",
+                table: "Member",
+                column: "PresenterId",
+                principalTable: "Presenter",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Presentation_Presenter_PresenterId",
+                table: "Presentation",
+                column: "PresenterId",
+                principalTable: "Presenter",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Models/KiCdbContext.cs
+++ b/Models/KiCdbContext.cs
@@ -19,6 +19,7 @@ namespace KiCData.Models
         public DbSet<Member> Members { get; set; }
         public DbSet<Event> Events { get; set; }
         public DbSet<Presenter> Presenters { get; set; }
+        public DbSet<PresenterSocial> PresenterSocials { get; set; }
         public DbSet<Presentation> Presentations { get; set; }
         public DbSet<ClubMember> ClubMembers { get; set; }
         public DbSet<Attendee> Attendees { get; set; }

--- a/Models/Member.cs
+++ b/Models/Member.cs
@@ -51,9 +51,6 @@ namespace KiCData.Models
         public Volunteer? Volunteer { get; set; }
         public Staff? Staff { get; set; }
 
-        public int? PresenterId { get; set; }
-        public Presenter? Presenter { get; set; }
-
         public User? User { get; set; }
         public Attendee? Attendee { get; set; }
 

--- a/Models/Presentation.cs
+++ b/Models/Presentation.cs
@@ -26,8 +26,8 @@ namespace KiCData.Models
         [Display(Name = "To what kink or kinks does your class pertain?")]
         public string? Type { get; set; }
 
-        public int PresenterId { get; set; }
-        public virtual Presenter? Presenter { get; set; }
+        public ICollection<Presenter> Presenters { get; set; } = new List<Presenter>();
+
 
         public int EventId { get; set; }
         public virtual Event Event { get; set; }

--- a/Models/Presenter.cs
+++ b/Models/Presenter.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace KiCData.Models
 {
     [Table("Presenter")]
-    public class Presenter 
+    public class Presenter
     {
         [Key]
         //[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
@@ -16,7 +16,7 @@ namespace KiCData.Models
         public string? PublicName { get; set; }
 
         [Display(Name = @"A tagline or short description of you or your business.")]
-        public string? Tagline { get; set; }        
+        public string? Tagline { get; set; }
 
         [Display(Name = @"A short bio about you or your business.")]
         public string? Bio { get; set; }
@@ -29,7 +29,14 @@ namespace KiCData.Models
         public string? Details { get; set; }
         public string? ImgPath { get; set; }
 
-        public ICollection<Member> Members { get; set; } = new List<Member>();
+        public Member? Member { get; set; }
+
+        [ForeignKey("Member")]
+        public int? MemberId { get; set; }
+        
+        public ICollection<Presentation> Presentations { get; set; } = new List<Presentation>();
+
+        public virtual ICollection<PresenterSocial> Socials { get; set; } = new List<PresenterSocial>();
 
     }
 }

--- a/Models/PresenterSocial.cs
+++ b/Models/PresenterSocial.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace KiCData.Models
+{
+  [Table("PresenterSocial")]
+  public class PresenterSocial
+  {
+      public int Id { get; set; }
+
+      public string Platform { get; set; } = default!;
+
+      public string Handle { get; set; } = default!;
+
+      public int PresenterId { get; set; }
+
+      public Presenter Presenter { get; set; } = default!;
+  }
+}


### PR DESCRIPTION
This does the following:
1. Makes Member table 1-1 relation with the Presenter table (it was previously 1-to-many)
2. Adds `PresenterSocial` table to store 1 or more socials
3. Updates Presenter/Presentation relations to be a many-to-many relationship