### PR TITLE
Feature aws ses

### DIFF
--- a/KiCData.csproj
+++ b/KiCData.csproj
@@ -20,8 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleEmail" Version="4.0.1.1" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
-    <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
     <PackageReference Include="MailKit" Version="4.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/KiCData.csproj
+++ b/KiCData.csproj
@@ -19,6 +19,9 @@
 </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SimpleEmail" Version="4.0.1.1" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.21" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
     <PackageReference Include="MailKit" Version="4.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/Models/WebModels/FormMessage.cs
+++ b/Models/WebModels/FormMessage.cs
@@ -1,17 +1,18 @@
 ﻿using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 
 namespace KiCData.Models.WebModels
 {
     public class FormMessage
     {
-        public List<string>? To { get; set; }
+        public List<string>? To { get; set; } = new();
 
-        public List<string>? Cc { get; set; }
+        public List<string>? Cc { get; set; } = new();
 
-        public List<string>? Bcc { get; set; }
+        public List<string>? Bcc { get; set; } = new();
 
-        public string From { get; set; }
+        public string From { get; set; } = "mailer-daemon@kicevents.com";
 
         public string? Subject { get; set; }
 
@@ -19,20 +20,9 @@ namespace KiCData.Models.WebModels
 
         public string? Text { get; set; }
 
-        public StringBuilder? HtmlBuilder { get; set; }
+        public StringBuilder? HtmlBuilder { get; set; } = new();
 
-        public string Sender { get; set; }
-
-        public FormMessage()
-        {
-            To = new List<string>();
-            Cc = new List<string>();
-            Bcc = new List<string>();
-            HtmlBuilder = new StringBuilder();
-            From = "mailer-daemon@kicevents.com";
-            Sender = "mailer-daemon@kicevents.com";
-            Cc.Add("technology@kicevents.com");
-        }
+        public string Sender { get; set; } = "mailer-daemon@kicevents.com";
 
         public void BuildHtml()
         {

--- a/Services/SESEmailService.cs
+++ b/Services/SESEmailService.cs
@@ -1,0 +1,103 @@
+﻿using Amazon;
+using Amazon.SimpleEmail;
+using Amazon.SimpleEmail.Model;
+using Hangfire;
+using KiCData.Models.WebModels;
+using Microsoft.Extensions.Configuration;
+
+namespace KiCData.Services
+{
+    public class SESEmailService : IEmailService
+    {
+        private readonly IConfigurationRoot _config;
+        private readonly IKiCLogger _logger;
+        private readonly AmazonSimpleEmailServiceClient _client;
+        private readonly IBackgroundJobClient _backgroundJobClient;
+
+        public SESEmailService(IConfigurationRoot config, IKiCLogger logger, IBackgroundJobClient backgroundJobClient)
+        {
+            this._config = config;
+            this._logger = logger;
+            var awsRegion = RegionEndpoint.GetBySystemName(config["AWS:Region"]);
+            this._client = new AmazonSimpleEmailServiceClient(config["AWS:AccessKey"], config["AWS:SecretKey"], awsRegion);
+            this._backgroundJobClient =  backgroundJobClient;
+        }
+
+        /// <summary>
+        /// Creates a form message with the necessary details to be serialized into an email.
+        /// </summary>
+        /// <param name="rep">The member of staff to whom the email should be sent.</param>
+        /// <returns>FormMessage</returns>
+        public FormMessage FormSubmissionEmailFactory(string rep)
+        {
+            FormMessage message = new FormMessage();
+
+            message.To.Add(_config["Email Addresses:" + rep]);
+            message.Cc.Add(_config["Email Addresses:Admin"]);
+            message.Subject = "Web Form Submission | " + rep + " | " + DateTime.Now.ToString();
+            message.From = _config["Email Addresses:From"];
+
+
+            return message;
+        }
+
+        /// <summary>
+        /// Sends the given message as an email.
+        /// </summary>
+        /// <param name="message">The FormMessage to be sent.</param>
+        /// <returns>Task</returns>
+        /// <exception cref="Exception"></exception>
+        public void SendEmail(FormMessage message)
+        {
+            if(message.Html is null && message.HtmlBuilder is null)
+            {
+                throw new Exception("Empty FormMessage");
+            }
+
+            if (message.Html is null)
+            {
+                message.BuildHtml();
+            }
+
+            _logger.LogText("Sending email. ");
+            
+            // message fields can be null, so coalesce to an empty list if they are null
+            List<string> toAddresses = message.To ?? [];
+            List<string> ccAddresses = message.Cc ?? [];
+            List<string> bccAddresses = message.Bcc ?? [];
+
+            var dest = new Destination
+            {
+                BccAddresses = bccAddresses,
+                CcAddresses = ccAddresses,
+                ToAddresses = toAddresses
+            };
+            var msg = new Message
+            {
+                Subject = new Content
+                {
+                    Charset = "UTF-8",
+                    Data = message.Subject
+                },
+                Body = new Body
+                {
+                    Html = new Content
+                    {
+                        Charset = "UTF-8",
+                        Data = message.Html
+                    }
+                }
+            };
+            var req = new SendEmailRequest
+            {
+                Destination = dest,
+                Message = msg,
+                Source = message.From
+            };
+            _client.SendEmailAsync(req, CancellationToken.None).Wait();
+            //this._backgroundJobClient.Enqueue(() => _client.SendEmailAsync(req, CancellationToken.None) );
+
+            _logger.LogText("Message sent...");
+        }
+    }
+}


### PR DESCRIPTION
Adds the `SESEmailService` to allow sending of emails through AWS SES.

## Config changes

This change requires new properties in your environment's `appsettings.json` file. Additionally, it may require changes to your db connection string to support the full hangfire feature set.

Example `appsettings.json` file:
```json
{
    "Database": {
        "Server": "kicweb-db",
        "Port": "3306",
        "Username": "kicweb",
        "Password": "kicweb",
        "Database": "kicweb",
        "ConnectionString": "Server=kicweb-db;Port=3306;Database=kicweb;Username=kicweb;Password=kicweb;Allow User Variables=True"
    },
    "AWS": {
	"AccessKey": "AWS-IAM-Access-key-here",
	"SecretKey": "AWS-IAM-Access-secret-here",
	"Region": "aws-region-identifer"
    },
    "Email Addresses": {
	    "From": "mailer-daemon@kicevents.com",
	    "Archive": "technology@kicevents.com"
    }
}
```

* `Database:ConnectionString` requires `Allow User Variables=True` for hangfire support
* New section `AWS`
* New section `Email Addresses`
  - `From` represents the sender email address to use in SES
  - `Archive` email address is added as a BCC recipient on all outgoing emails